### PR TITLE
fix: Expose rendering mode to mobile editor

### DIFF
--- a/packages/editor/src/store/reducer.native.js
+++ b/packages/editor/src/store/reducer.native.js
@@ -9,6 +9,7 @@ import { combineReducers } from '@wordpress/data';
 import {
 	postId,
 	postType,
+	renderingMode,
 	saving,
 	postLock,
 	postSavingLock,
@@ -82,6 +83,7 @@ export default combineReducers( {
 	postId,
 	postType,
 	postTitle,
+	renderingMode,
 	saving,
 	postLock,
 	postSavingLock,


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Expose an accurate rendering mode to the mobile editor. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Relates to https://github.com/WordPress/gutenberg/pull/62304. Recent changes in the editor provider enable setting the rendering mode via post type. The changes result conditionally rendering the visual editor until the mode is determined. Without the required reducers, the mobile editor never updated the rendering mode state, thus never rendering the visual editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Export the rendering mode selector for the mobile editor. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
N/A, no user-facing changes. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes. 